### PR TITLE
Rename module from glueops to autoglue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/glueops/terraform-provider-gsot
+module terraform-provider-autoglue
 
 go 1.25.3
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update Go module name from `glueops` to `autoglue`

- Simplify module path to reflect new project identity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["github.com/glueops/terraform-provider-gsot"] -- "rename module" --> new["terraform-provider-autoglue"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update module name to autoglue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

<ul><li>Changed module declaration from <br><code>github.com/glueops/terraform-provider-gsot</code> to <br><code>terraform-provider-autoglue</code><br> <li> Simplified module path to reflect project rebranding</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-provider-autoglue/pull/2/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).